### PR TITLE
Minor bugfix: Moved assignment of postNotifications parameter value

### DIFF
--- a/AppMessage/AppMessage/CloudKit/EVCloudData.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudData.swift
@@ -776,6 +776,11 @@ public class EVCloudData: NSObject {
         dataChangedHandler:(() -> Void)? = nil,
         errorHandler:((error: NSError) -> Void)? = nil
         ) -> Void {
+            // Set the post notifications flag for this filter ID before checking the cache
+            if postNotifications != nil && postNotifications! {
+                self.postNotifications[filterId] = postNotifications!
+            }
+            
             // If we have a cache for this filter, then first return that.
             if restoreDataForFilter(filterId) {
                 if let filterData = self.data[filterId] as? [T] {
@@ -803,10 +808,6 @@ public class EVCloudData: NSObject {
             self.cachingLastWrite[filterId] = NSDate()
             self.cachingChangesCount[filterId] = 0
             self.cachingStrategies[filterId] = cachingStrategy
-            
-            if postNotifications != nil && postNotifications! {
-                self.postNotifications[filterId] = postNotifications!
-            }
             
             // Wrapping (Type and optional) the generic function so that we can add it to the collection and prevent nil reference exceptions
             if insertedHandler != nil {

--- a/AppMessage/Podfile.lock
+++ b/AppMessage/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - AsyncSwift (1.6.4)
   - CRToast (0.0.9)
-  - EVReflection (2.11.3)
+  - EVReflection (2.12.1)
   - JSQMessagesViewController (7.2.0):
     - JSQSystemSoundPlayer (~> 2.0.1)
   - JSQSystemSoundPlayer (2.0.1)
@@ -36,7 +36,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AsyncSwift: 3c90beed237324f1b57e1f1c414dc5501985d208
   CRToast: 5a78c22b921c5ed3487488af605bc403a9c92fed
-  EVReflection: 2f8ca960cf862b6932578ffdac4f869f1c5a06ad
+  EVReflection: 1b74180614fe32f6fd3b37e32006f0047343f0c7
   JSQMessagesViewController: 73cab48aa92fc2d512f3b6724f3425cc47a19eb5
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
   PermissionScope: 1d27791185cca10c26f84d1aab905117dde50f39


### PR DESCRIPTION
A “data completed (from cache)” notification wasn’t being posted if data for the filterID being connected to was locally cached and immediately returned.