### PR TITLE
Completion Handlers, iCloud Status Monitoring, Per-User Local Cache Changes FOR REVIEW

### DIFF
--- a/AppMessage/AppMessage/CloudKit/EVCloudData.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudData.swift
@@ -982,8 +982,10 @@ public class EVCloudData: NSObject {
     - parameter error: Non-nil if an error occurred while attempting to access the current iCloud account
     :return: No return value
     */
-    private func defaultDBInitializationCompleteHandler(_: CKAccountStatus, error: NSError?) {
-        disconnectAll()
+    private func defaultDBInitializationCompleteHandler(accountStatus: CKAccountStatus, error: NSError?) {
+        if accountStatus != .Available, let _ = error {
+            disconnectAll()
+        }
     }
     
     // ------------------------------------------------------------------------

--- a/AppMessage/AppMessage/CloudKit/EVCloudData.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudData.swift
@@ -192,6 +192,9 @@ public class EVCloudData: NSObject {
             static let token = EVCloudKitDao.insertPublicDBInitializationCompleteHandler(instance.defaultDBInitializationCompleteHandler)
         }
         Static.instance.dao = EVCloudKitDao.publicDB
+        // Force instantiation of token
+        let _ = Static.token
+        
         return Static.instance
     }
     
@@ -216,6 +219,9 @@ public class EVCloudData: NSObject {
             static let token = EVCloudKitDao.insertPrivateDBInitializationCompleteHandler(instance.defaultDBInitializationCompleteHandler)
         }
         Static.instance.dao = EVCloudKitDao.privateDB
+        // Force instantiation of token
+        let _ = Static.token
+
         return Static.instance
     }
     

--- a/AppMessage/AppMessage/CloudKit/EVCloudData.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudData.swift
@@ -497,11 +497,14 @@ public class EVCloudData: NSObject {
                     self.data[filterId] = theData
                     resultHandler?(true)
                     return
+                } else {
+                    EVLog("Unable to restore locally-cached filter data for \(filterId); file not found")
                 }
+            } else {
+                EVLog("Unable to restore locally-cached filter data for \(filterId); no iCloud account currently available")
             }
-            EVLog("Unable to restore locally-cached filter data for \(filterId); no iCloud account currently available")
-            resultHandler?(false)
         }
+        resultHandler?(false)
     }
     
     /**

--- a/AppMessage/AppMessage/CloudKit/EVCloudData.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudData.swift
@@ -142,7 +142,7 @@ public class EVCloudData: NSObject {
     :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
     */
     public class func addPublicDBInitializationCompleteHandler(handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        return EVCloudKitDao.insertPublicDBInitializationCompleteHandler(handler)
+        return EVCloudKitDao.addPublicDBInitializationCompleteHandler(handler)
     }
     
     /**
@@ -152,7 +152,7 @@ public class EVCloudData: NSObject {
      :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
      */
     public class func addPublicDBInitializationCompleteHandler(forContainer: String, handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        return EVCloudKitDao.insertPublicDBInitializationCompleteHandler(forContainer, handler: handler)
+        return EVCloudKitDao.addPublicDBInitializationCompleteHandler(forContainer, handler: handler)
     }
 
     /**
@@ -162,7 +162,7 @@ public class EVCloudData: NSObject {
      :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
      */
     public class func addPrivateDBInitializationCompleteHandler(handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        return EVCloudKitDao.insertPrivateDBInitializationCompleteHandler(handler)
+        return EVCloudKitDao.addPrivateDBInitializationCompleteHandler(handler)
     }
     
     /**
@@ -172,7 +172,7 @@ public class EVCloudData: NSObject {
      :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
      */
     public class func addPrivateDBInitializationCompleteHandler(forContainer: String, handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        return EVCloudKitDao.insertPrivateDBInitializationCompleteHandler(forContainer, handler: handler)
+        return EVCloudKitDao.addPrivateDBInitializationCompleteHandler(forContainer, handler: handler)
     }
 
     // ------------------------------------------------------------------------
@@ -293,11 +293,6 @@ public class EVCloudData: NSObject {
         NSTimer.scheduledTimerWithTimeInterval(60, target: self, selector: Selector("backupAllData"), userInfo: nil, repeats: true)
     }
     
-    deinit {
-        initializationCompleteHandlerToken?.releaseToken()
-        initializationCompleteHandlerToken = nil
-    }
-    
     // ------------------------------------------------------------------------
     // MARK: - class variables
     // ------------------------------------------------------------------------
@@ -350,10 +345,6 @@ public class EVCloudData: NSObject {
      A dictionary of delete event handlers. Each filterId is a dictionary entry containing a delete event handler
      */
     public var deletedHandlers = Dictionary<String, (recordId: String, dataIndex: Int) -> Void>()
-    /**
-     Token returned by EVCloudKitDao when our initialization completion handler is registered
-     */
-    private var initializationCompleteHandlerToken: DBInitializationCompleteHandlerToken? = nil
     
     
     // ------------------------------------------------------------------------

--- a/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
@@ -274,7 +274,7 @@ public class EVCloudKitDao {
 
         // Check for our instance already being initialized and invoke callCompletionHandlers if so. Any completion handlers added since our instance was initialized will be called.
         if let status = Static.instance.accountStatus {
-            callCompletionHandlers(publicDBInitializationCompleteHandlers, status: status, error: nil)
+            Static.instance.callCompletionHandlers(status, error: nil)
         }
         
         return Static.instance
@@ -301,7 +301,7 @@ public class EVCloudKitDao {
 
         // Check for our instance already being initialized and invoke callCompletionHandlers if so. Any completion handlers added since our instance was initialized will be called.
         if let status = Static.instance.accountStatus {
-            callCompletionHandlers(privateDBInitializationCompleteHandlers, status: status, error: nil)
+            Static.instance.callCompletionHandlers(status, error: nil)
         }
         
         return Static.instance
@@ -336,7 +336,7 @@ public class EVCloudKitDao {
         if let containerInstance = containerWrapperInstance.publicContainers[containerIdentifier] {
             // Check for our instance already being initialized and invoke callCompletionHandlers if so. Any completion handlers added since our instance was initialized will be called.
             if let status = containerInstance.accountStatus {
-                callCompletionHandlers(publicDBInitializationCompleteHandlersForContainer[containerIdentifier], status: status, error: nil)
+                containerInstance.callCompletionHandlers(status, error: nil)
             }
             
             return containerInstance
@@ -357,7 +357,7 @@ public class EVCloudKitDao {
         if let containerInstance = containerWrapperInstance.privateContainers[containerIdentifier] {
             // Check for our instance already being initialized and invoke callCompletionHandlers if so. Any completion handlers added since our instance was initialized will be called.
             if let status = containerInstance.accountStatus {
-                callCompletionHandlers(privateDBInitializationCompleteHandlersForContainer[containerIdentifier], status: status, error: nil)
+                containerInstance.callCompletionHandlers(status, error: nil)
             }
             
             return containerInstance
@@ -469,7 +469,7 @@ public class EVCloudKitDao {
             EVLog("Account status = \(status.hashValue) (0=CouldNotDetermine/1=Available/2=Restricted/3=NoAccount)")
             
             // Call all assigned completion handlers
-            EVCloudKitDao.callCompletionHandlers(self.initializationCompleteHandlers, status: status, error: error, invokeAll: true)
+            self.callCompletionHandlers(status, error: error, invokeAll: true)
         })
 
         EVLog("Container identifier = \(container.containerIdentifier)")
@@ -482,14 +482,14 @@ public class EVCloudKitDao {
     - parameter status: Current iCloud account status
     - parameter error: Optional error info if the iCloud container's accountStatusWithCompletionHandler method returns an error
     */
-    private class func callCompletionHandlers(initializationCompleteHandlers: HandlerCollection?, status: CKAccountStatus, error: NSError?, invokeAll: Bool = false) {
+    private func callCompletionHandlers(status: CKAccountStatus, error: NSError?, invokeAll: Bool = false) {
         if let handlers = initializationCompleteHandlers {
             // Verify that all handlers should be called or that at least one of the handlers hasn't been already called
             if invokeAll || handlers.hasNewHandlers {
                 // Set the collection's hasNewHandlers flag to false since we're about to call the handlers
                 handlers.hasNewHandlers = false
                 // Delay so our instance is returned and processed as needed before any newly-added completion handlers are called
-                delay(0.1) {
+                EVCloudKitDao.delay(0.1) {
                     for wrapper in handlers.collection {
                         if invokeAll || !wrapper.hasBeenInvoked {
                             wrapper.invoke(status, error: error)

--- a/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
@@ -1313,15 +1313,10 @@ public class EVCloudKitDao {
     private func dictToCKRecord(record: CKRecord, dict: NSDictionary, root:String = "") {
         for (key, value) in dict {
             if !(["recordID", "recordType", "creationDate", "creatorUserRecordID", "modificationDate", "lastModifiedUserRecordID", "recordChangeTag", "encodedSystemFields"]).contains(key as! String) {
-<<<<<<< HEAD
-                if let _ = value as? NSNull {
-//                    record.setValue(nil, forKey: key) // Swift can not set a value on a nullable type.
-=======
                 if value is NSNull {
                     // record.setValue(nil, forKey: key) // Swift can not set a value on a nulable type.
                 } else if let dict = value as? NSDictionary {
                     dictToCKRecord(record, dict: dict, root: "\(root)\(key as! String)__")
->>>>>>> evermeer/master
                 } else if key as! String != "recordID" {
                     record.setValue(value, forKey: "\(root)\(key as! String)")
                 }

--- a/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
@@ -1129,14 +1129,23 @@ public class EVCloudKitDao {
         }
         
         if reset {
-            // Update connectStatus property on all instances
+            // Update activeUserId, activeUser and connectStatus properties on all instances
+            
+            publicDB.activeUserId = nil
+            publicDB.activeUser = nil
             publicDB.initializeDatabase(nil, initializationCompleteHandlers: publicDBInitializationCompleteHandlers)
             for (identifier, instance) in containerWrapperInstance.publicContainers {
+                instance.activeUserId = nil
+                instance.activeUser = nil
                 instance.initializeDatabase(identifier, initializationCompleteHandlers: publicDBInitializationCompleteHandlersForContainer[identifier])
             }
 
+            privateDB.activeUserId = nil
+            privateDB.activeUser = nil
             privateDB.initializeDatabase(nil, initializationCompleteHandlers: privateDBInitializationCompleteHandlers)
             for (identifier, instance) in containerWrapperInstance.privateContainers {
+                instance.activeUserId = nil
+                instance.activeUser = nil
                 instance.initializeDatabase(identifier, initializationCompleteHandlers: privateDBInitializationCompleteHandlersForContainer[identifier])
             }
             

--- a/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
@@ -101,6 +101,21 @@ private class ConnectStatusCompletionHandlerWrapper: DBInitializationCompleteHan
     }
 }
 
+private class HandlerCollection {
+    var collection = [ConnectStatusCompletionHandlerWrapper]()
+    var hasNewHandlers = false
+    
+    func addHandlerToCollection(handler: DBInitializationCompleteHandler) -> ConnectStatusCompletionHandlerWrapper {
+        hasNewHandlers = true
+        return ConnectStatusCompletionHandlerWrapper(collection: &collection, insert: false, handler: handler)
+    }
+    
+    func insertHandlerIntoCollection(handler: DBInitializationCompleteHandler) -> ConnectStatusCompletionHandlerWrapper {
+        hasNewHandlers = true
+        return ConnectStatusCompletionHandlerWrapper(collection: &collection, insert: true, handler: handler)
+    }
+}
+
 /**
 Class for simplified access to  Apple's CloudKit data where you still have full control
 */
@@ -113,7 +128,7 @@ public class EVCloudKitDao {
     Singleton assignment of initializationComplete handlers that are called when access to the default public container is (re)initialized.
     Is called upon successful or failed completion of database initialization attempts during initial access and again if the iCloud account status changes
     */
-    private static var publicDBInitializationCompleteHandlers = [ConnectStatusCompletionHandlerWrapper]()
+    private static var publicDBInitializationCompleteHandlers = HandlerCollection()
     
     /**
     Method used to add an initializationComplete handler that is called when access to the default public container is (re)initialized. The returned token can be retained by the calling code and removed from the list of handlers when it is no longer needed by calling its removeToken method.
@@ -122,7 +137,7 @@ public class EVCloudKitDao {
     :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
     */
     public class func addPublicDBInitializationCompleteHandler(handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        return ConnectStatusCompletionHandlerWrapper(collection: &publicDBInitializationCompleteHandlers, insert: false, handler: handler)
+        return publicDBInitializationCompleteHandlers.addHandlerToCollection(handler)
     }
     
     /**
@@ -132,14 +147,14 @@ public class EVCloudKitDao {
     :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
     */
     internal class func insertPublicDBInitializationCompleteHandler(handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        return ConnectStatusCompletionHandlerWrapper(collection: &publicDBInitializationCompleteHandlers, insert: true, handler: handler)
+        return publicDBInitializationCompleteHandlers.insertHandlerIntoCollection(handler)
     }
     
     /**
      Singleton assignment of initializationComplete handlers that are called when access to a specified public container is (re)initialized.
      Is called upon successful or failed completion of database initialization attempts during initial access and again if the iCloud account status changes
      */
-    private static var publicDBInitializationCompleteHandlersForContainer = Dictionary<String, [ConnectStatusCompletionHandlerWrapper]>()
+    private static var publicDBInitializationCompleteHandlersForContainer = Dictionary<String, HandlerCollection>()
     
     /**
      Method used to add an initializationComplete handler that is called when access to the specified public container is (re)initialized. The returned token can be retained by the calling code and released when it is no longer needed by calling its releaseToken method.
@@ -149,9 +164,9 @@ public class EVCloudKitDao {
      :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
      */
     public class func addPublicDBInitializationCompleteHandler(forContainer: String, handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        var collection = getCollectionFromDictionary(forContainer, dict: &publicDBInitializationCompleteHandlersForContainer)
+        let collection = getCollectionFromDictionary(forContainer, dict: &publicDBInitializationCompleteHandlersForContainer)
         
-        return ConnectStatusCompletionHandlerWrapper(collection: &collection, insert: false, handler: handler)
+        return collection.addHandlerToCollection(handler)
     }
     
     /**
@@ -162,16 +177,16 @@ public class EVCloudKitDao {
      :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
      */
     internal class func insertPublicDBInitializationCompleteHandler(forContainer: String, handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        var collection = getCollectionFromDictionary(forContainer, dict: &publicDBInitializationCompleteHandlersForContainer)
+        let collection = getCollectionFromDictionary(forContainer, dict: &publicDBInitializationCompleteHandlersForContainer)
         
-        return ConnectStatusCompletionHandlerWrapper(collection: &collection, insert: true, handler: handler)
+        return collection.insertHandlerIntoCollection(handler)
     }
     
     /**
      Singleton assignment of initializationComplete handlers that are called when access to the default private container is (re)initialized.
      Is called upon successful or failed completion of database initialization attempts during initial access and again if the iCloud account status changes
      */
-    private static var privateDBInitializationCompleteHandlers = [ConnectStatusCompletionHandlerWrapper]()
+    private static var privateDBInitializationCompleteHandlers = HandlerCollection()
     
     /**
      Method used to add an initializationComplete handler that is called when access to the default private container is (re)initialized. The returned token can be retained by the calling code and removed from the list of handlers when it is no longer needed by calling its removeToken method.
@@ -180,7 +195,7 @@ public class EVCloudKitDao {
      :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
      */
     public class func addPrivateDBInitializationCompleteHandler(handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        return ConnectStatusCompletionHandlerWrapper(collection: &privateDBInitializationCompleteHandlers, insert: false, handler: handler)
+        return privateDBInitializationCompleteHandlers.addHandlerToCollection(handler)
     }
     
     /**
@@ -190,14 +205,14 @@ public class EVCloudKitDao {
      :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
      */
     internal class func insertPrivateDBInitializationCompleteHandler(handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        return ConnectStatusCompletionHandlerWrapper(collection: &privateDBInitializationCompleteHandlers, insert: true, handler: handler)
+        return privateDBInitializationCompleteHandlers.insertHandlerIntoCollection(handler)
     }
     
     /**
      Singleton assignment of initializationComplete handlers that are called when access to a specified private container is (re)initialized.
      Is called upon successful or failed completion of database initialization attempts during initial access and again if the iCloud account status changes
      */
-    private static var privateDBInitializationCompleteHandlersForContainer = Dictionary<String, [ConnectStatusCompletionHandlerWrapper]>()
+    private static var privateDBInitializationCompleteHandlersForContainer = Dictionary<String, HandlerCollection>()
     
     /**
      Method used to add an initializationComplete handler that is called when access to the specified private container is (re)initialized. The returned token can be retained by the calling code and released when it is no longer needed by calling its releaseToken method.
@@ -207,9 +222,9 @@ public class EVCloudKitDao {
      :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
      */
     public class func addPrivateDBInitializationCompleteHandler(forContainer: String, handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        var collection = getCollectionFromDictionary(forContainer, dict: &privateDBInitializationCompleteHandlersForContainer)
+        let collection = getCollectionFromDictionary(forContainer, dict: &privateDBInitializationCompleteHandlersForContainer)
         
-        return ConnectStatusCompletionHandlerWrapper(collection: &collection, insert: false, handler: handler)
+        return collection.addHandlerToCollection(handler)
     }
     
     /**
@@ -220,9 +235,9 @@ public class EVCloudKitDao {
      :return: A token to be retained until the passed handler should no longer be called, at which point the token's releaseToken method should be called.
      */
     internal class func insertPrivateDBInitializationCompleteHandler(forContainer: String, handler: DBInitializationCompleteHandler) -> DBInitializationCompleteHandlerToken {
-        var collection = getCollectionFromDictionary(forContainer, dict: &privateDBInitializationCompleteHandlersForContainer)
+        let collection = getCollectionFromDictionary(forContainer, dict: &privateDBInitializationCompleteHandlersForContainer)
         
-        return ConnectStatusCompletionHandlerWrapper(collection: &collection, insert: true, handler: handler)
+        return collection.insertHandlerIntoCollection(handler)
     }
     
     /**
@@ -232,10 +247,10 @@ public class EVCloudKitDao {
      
      :return: An array of ConnectStatusCompletionHandlerWrapper instances for the requested container
     */
-    private class func getCollectionFromDictionary(forContainer: String, inout dict : Dictionary<String, [ConnectStatusCompletionHandlerWrapper]>) -> [ConnectStatusCompletionHandlerWrapper] {
+    private class func getCollectionFromDictionary(forContainer: String, inout dict : Dictionary<String, HandlerCollection>) -> HandlerCollection {
         var collection = dict[forContainer]
         if collection == nil {
-            collection = [ConnectStatusCompletionHandlerWrapper]()
+            collection = HandlerCollection()
             dict[forContainer] = collection
         }
         
@@ -408,7 +423,7 @@ public class EVCloudKitDao {
      
     - parameter initializationCompleteHandlers: ConnectStatusCompletionHandlerWrapper instances to be invoked once initialization is completed. Provides account status and error state. Will be called again if the iCloud account status changes, as database must be reinitalized in that case.
     */
-    private init(initializationCompleteHandlers: [ConnectStatusCompletionHandlerWrapper]?) {
+    private init(initializationCompleteHandlers: HandlerCollection?) {
         self.initializeDatabase(nil, initializationCompleteHandlers: initializationCompleteHandlers)
     }
 
@@ -418,7 +433,7 @@ public class EVCloudKitDao {
     - parameter containerIdentifier: Passing on the name of the container
     - parameter initializationCompleteHandlers: ConnectStatusCompletionHandlerWrapper instances to be invoked once initialization is completed. Provides account status and error state. Will be called again if the iCloud account status changes, as database must be reinitalized in that case.
     */
-    private init(containerIdentifier: String, initializationCompleteHandlers: [ConnectStatusCompletionHandlerWrapper]?) {
+    private init(containerIdentifier: String, initializationCompleteHandlers: HandlerCollection?) {
         self.initializeDatabase(containerIdentifier, initializationCompleteHandlers: initializationCompleteHandlers)
     }
 
@@ -428,7 +443,7 @@ public class EVCloudKitDao {
     - parameter containerIdentifier: Passing on the name of the container
     - parameter initializationCompleteHandlers: ConnectStatusCompletionHandlerWrapper instances to be invoked once initialization is completed. Provides account status and error state. Will be called again if the iCloud account status changes, as database must be reinitalized in that case.
     */
-    private func initializeDatabase(containerIdentifier: String? = nil, initializationCompleteHandlers: [ConnectStatusCompletionHandlerWrapper]?) {
+    private func initializeDatabase(containerIdentifier: String? = nil, initializationCompleteHandlers: HandlerCollection?) {
         if let identifier = containerIdentifier {
             container = CKContainer(identifier: identifier)
         } else {
@@ -462,13 +477,18 @@ public class EVCloudKitDao {
     - parameter status: Current iCloud account status
     - parameter error: Optional error info if the iCloud container's accountStatusWithCompletionHandler method returns an error
     */
-    private class func callCompletionHandlers(initializationCompleteHandlers: [ConnectStatusCompletionHandlerWrapper]?, status: CKAccountStatus, error: NSError?, invokeAll: Bool = false) {
+    private class func callCompletionHandlers(initializationCompleteHandlers: HandlerCollection?, status: CKAccountStatus, error: NSError?, invokeAll: Bool = false) {
         if let handlers = initializationCompleteHandlers {
-            // Delay so our instance is returned and processed as needed before any newly-added completion handlers are called
-            delay(0.1) {
-                for wrapper in handlers {
-                    if invokeAll || !wrapper.hasBeenInvoked {
-                        wrapper.invoke(status, error: error)
+            // Verify that all handlers should be called or that at least one of the handlers hasn't been already called
+            if invokeAll || handlers.hasNewHandlers {
+                // Set the collection's hasNewHandlers flag to false since we're about to call the handlers
+                handlers.hasNewHandlers = false
+                // Delay so our instance is returned and processed as needed before any newly-added completion handlers are called
+                delay(0.1) {
+                    for wrapper in handlers.collection {
+                        if invokeAll || !wrapper.hasBeenInvoked {
+                            wrapper.invoke(status, error: error)
+                        }
                     }
                 }
             }
@@ -1114,7 +1134,7 @@ public class EVCloudKitDao {
             
             // Check for a previous token being written to user defaults and compare tokens if found
             let existingToken = NSUserDefaults.standardUserDefaults().stringForKey(tokenKey)
-            if existingToken != currentToken {
+            if currentToken == nil || existingToken != currentToken {
                 if currentToken != nil {
                     NSUserDefaults.standardUserDefaults().setValue(currentToken, forKey: tokenKey)
                 } else {

--- a/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
@@ -270,7 +270,7 @@ public class EVCloudKitDao {
         /**
         Singleton structure
         */
-        struct Static { static let instance: EVCloudKitDao = EVCloudKitDao(initializationCompleteHandlers: EVCloudKitDao.publicDBInitializationCompleteHandlers) }
+        struct Static { static let instance: EVCloudKitDao = EVCloudKitDao(type: .IsPublic, initializationCompleteHandlers: EVCloudKitDao.publicDBInitializationCompleteHandlers) }
 
         // Check for our instance already being initialized and invoke callCompletionHandlers if so. Any completion handlers added since our instance was initialized will be called.
         if let status = Static.instance.accountStatus {
@@ -295,8 +295,8 @@ public class EVCloudKitDao {
     :return: The EVCLoudKitDao object
     */
     public class var privateDB: EVCloudKitDao {
-        struct Static { static let instance: EVCloudKitDao = EVCloudKitDao(initializationCompleteHandlers: EVCloudKitDao.privateDBInitializationCompleteHandlers) }
-        Static.instance.isType = .IsPrivate
+        struct Static { static let instance: EVCloudKitDao = EVCloudKitDao(type: .IsPrivate, initializationCompleteHandlers: EVCloudKitDao.privateDBInitializationCompleteHandlers) }
+
         Static.instance.database = Static.instance.container.privateCloudDatabase
 
         // Check for our instance already being initialized and invoke callCompletionHandlers if so. Any completion handlers added since our instance was initialized will be called.
@@ -344,8 +344,7 @@ public class EVCloudKitDao {
             return containerInstance
         }
         // Pass the initialization complete handler to our constructor if one was provided. Otherwise, pass the static publicDBInitializationCompleteHandler value (which may also be nil)
-        
-        containerWrapperInstance.publicContainers[containerIdentifier] =  EVCloudKitDao(containerIdentifier: containerIdentifier, initializationCompleteHandlers: publicDBInitializationCompleteHandlersForContainer[containerIdentifier])
+        containerWrapperInstance.publicContainers[containerIdentifier] = EVCloudKitDao(type: .IsPublic, containerIdentifier: containerIdentifier, initializationCompleteHandlers: publicDBInitializationCompleteHandlersForContainer[containerIdentifier])
 
         return containerWrapperInstance.publicContainers[containerIdentifier]!
     }
@@ -368,7 +367,7 @@ public class EVCloudKitDao {
             return containerInstance
         }
         // Pass the initialization complete handler to our constructor if one was provided. Otherwise, pass the static privateDBInitializationCompleteHandler value (which may also be nil)
-        containerWrapperInstance.privateContainers[containerIdentifier] =  EVCloudKitDao(containerIdentifier: containerIdentifier, initializationCompleteHandlers: privateDBInitializationCompleteHandlersForContainer[containerIdentifier])
+        containerWrapperInstance.privateContainers[containerIdentifier] =  EVCloudKitDao(type: .IsPrivate, containerIdentifier: containerIdentifier, initializationCompleteHandlers: privateDBInitializationCompleteHandlersForContainer[containerIdentifier])
 
         return containerWrapperInstance.privateContainers[containerIdentifier]!
     }
@@ -423,7 +422,8 @@ public class EVCloudKitDao {
      
     - parameter initializationCompleteHandlers: ConnectStatusCompletionHandlerWrapper instances to be invoked once initialization is completed. Provides account status and error state. Will be called again if the iCloud account status changes, as database must be reinitalized in that case.
     */
-    private init(initializationCompleteHandlers: HandlerCollection?) {
+    private init(type: InstanceType, initializationCompleteHandlers: HandlerCollection?) {
+        isType = type
         self.initializeDatabase(nil, initializationCompleteHandlers: initializationCompleteHandlers)
     }
 
@@ -433,7 +433,8 @@ public class EVCloudKitDao {
     - parameter containerIdentifier: Passing on the name of the container
     - parameter initializationCompleteHandlers: ConnectStatusCompletionHandlerWrapper instances to be invoked once initialization is completed. Provides account status and error state. Will be called again if the iCloud account status changes, as database must be reinitalized in that case.
     */
-    private init(containerIdentifier: String, initializationCompleteHandlers: HandlerCollection?) {
+    private init(type: InstanceType, containerIdentifier: String, initializationCompleteHandlers: HandlerCollection?) {
+        isType = type
         self.initializeDatabase(containerIdentifier, initializationCompleteHandlers: initializationCompleteHandlers)
     }
 

--- a/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
@@ -1360,12 +1360,14 @@ public class EVCloudKitDao {
     private func dictToCKRecord(record: CKRecord, dict: NSDictionary, root:String = "") {
         for (key, value) in dict {
             if !(["recordID", "recordType", "creationDate", "creatorUserRecordID", "modificationDate", "lastModifiedUserRecordID", "recordChangeTag", "encodedSystemFields"]).contains(key as! String) {
-                if value is NSNull {
-                    // record.setValue(nil, forKey: key) // Swift can not set a value on a nulable type.
-                } else if let dict = value as? NSDictionary {
-                    dictToCKRecord(record, dict: dict, root: "\(root)\(key as! String)__")
-                } else if key as! String != "recordID" {
-                    record.setValue(value, forKey: "\(root)\(key as! String)")
+                if key as! String != "recordIDName" || root == "" {
+                    if value is NSNull {
+                        // record.setValue(nil, forKey: key) // Swift can not set a value on a nulable type.
+                    } else if let dict = value as? NSDictionary {
+                        dictToCKRecord(record, dict: dict, root: "\(root)\(key as! String)__")
+                    } else if key as! String != "recordID" {
+                        record.setValue(value, forKey: "\(root)\(key as! String)")
+                    }
                 }
             }
         }

--- a/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
@@ -440,7 +440,6 @@ public class EVCloudKitDao {
             database = container.privateCloudDatabase
         }
 
-        let sema = dispatch_semaphore_create(0)
         container.accountStatusWithCompletionHandler({ status, error in
             if error != nil {
                 EVLog("Error: Initialising EVCloudKitDao - accountStatusWithCompletionHandler.\n\(error!.description)")
@@ -449,13 +448,10 @@ public class EVCloudKitDao {
             }
             EVLog("Account status = \(status.hashValue) (0=CouldNotDetermine/1=Available/2=Restricted/3=NoAccount)")
             
-            // Signal that the method can return before calling the completion handlers
-            dispatch_semaphore_signal(sema)
-
             // Call all assigned completion handlers
             EVCloudKitDao.callCompletionHandlers(initializationCompleteHandlers, status: status, error: error, invokeAll: true)
         })
-        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER)
+
         EVLog("Container identifier = \(container.containerIdentifier)")
     }
     

--- a/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudKitDao.swift
@@ -9,41 +9,6 @@ import Foundation
 import CloudKit
 import EVReflection
 
-<<<<<<< HEAD
-/**
-Wrapper class for being able to use a class instance Dictionary
-*/
-private class DaoContainerWrapper {
-    /**
-    Wrapping the public containers
-    */
-    var publicContainers : Dictionary<String,EVCloudKitDao> = Dictionary<String,EVCloudKitDao>()
-    /**
-    Wrapping the private containers
-    */
-    var privateContainers : Dictionary<String,EVCloudKitDao> = Dictionary<String,EVCloudKitDao>()
-}
-
-/**
-The functional statuses for a CloudKit error
-*/
-public enum HandleCloudKitErrorAs {
-    case Success,
-    Retry(afterSeconds:Double),
-    RecoverableError,
-    Fail
-}
-
-/**
-Enumeration that indicates if the instance's connection is to the user's private or app's public db
-*/
-public enum InstanceType {
-    case IsPrivate,
-    IsPublic
-}
-=======
->>>>>>> evermeer/master
-
 /**
 Type alias that defines a callback handler that is called when DB initialization attempt is completed
  */
@@ -54,69 +19,6 @@ Token protocol used to identify tokens returned by add..DBInitializationComplete
 */
 public protocol DBInitializationCompleteHandlerToken {
     func releaseToken()
-}
-
-/**
- Internal implementor of opaque token protocol returned by add..DBInitializationCompleteHandler methods. Used instead of directly storing handler references so removeToken can be implemented by filtering instances by comparing to self.
-*/
-private class ConnectStatusCompletionHandlerWrapper: DBInitializationCompleteHandlerToken {
-    /**
-    The collection that this wrapper is assigned to. Used when releaseToken is called.
-    */
-    private var collection: [ConnectStatusCompletionHandlerWrapper]
-    /**
-    The originally-passed handler that should be invoked.
-    */
-    private let handler: DBInitializationCompleteHandler
-    
-    /**
-    Boolean that indicates if the handler has been invoked yet. Used to determine if a handler should be explicitly called when a reference (publicDB, privateDB, etc.) that has already been initialized is retrieved.
-     */
-    var hasBeenInvoked: Bool = false
-    
-    /**
-    We modify the passed collection by inserting/appending ourselves, thus requiring it be defined as an inout var
-    */
-    init(inout collection: [ConnectStatusCompletionHandlerWrapper],  insert: Bool, handler: DBInitializationCompleteHandler) {
-        self.collection = collection
-        self.handler = handler
-        
-        if insert {
-            collection.insert(self, atIndex: 0)
-        } else {
-            collection.append(self)
-        }
-    }
-    
-    /**
-    Method called to invoke the originally-passed handler and to set our hasBeenInvoked flag to true
-    */
-    func invoke(status: CKAccountStatus, error: NSError?) {
-        hasBeenInvoked = true
-        handler(status: status, error: error)
-    }
-    
-    /**
-    Method called to release our instance from the collection we were assigned to
-    */
-    func releaseToken() {
-        collection = collection.filter { $0 !== self }
-    }
-}
-
-private class HandlerCollection {
-    var collection = [ConnectStatusCompletionHandlerWrapper]()
-    var hasNewHandlers = false
-    
-    func addHandlerToCollection(handler: DBInitializationCompleteHandler) -> ConnectStatusCompletionHandlerWrapper {
-        hasNewHandlers = true
-        return ConnectStatusCompletionHandlerWrapper(collection: &collection, insert: false, handler: handler)
-    }
-    
-    func insertHandlerIntoCollection(handler: DBInitializationCompleteHandler) -> ConnectStatusCompletionHandlerWrapper {
-        hasNewHandlers = true
-        return ConnectStatusCompletionHandlerWrapper(collection: &collection, insert: true, handler: handler)
-    }
 }
 
 /**
@@ -365,17 +267,8 @@ public class EVCloudKitDao {
             
             return containerInstance
         }
-<<<<<<< HEAD
         // Pass the initialization complete handler to our constructor if one was provided. Otherwise, pass the static privateDBInitializationCompleteHandler value (which may also be nil)
         containerWrapperInstance.privateContainers[containerIdentifier] =  EVCloudKitDao(type: .IsPrivate, containerIdentifier: containerIdentifier, initializationCompleteHandlers: privateDBInitializationCompleteHandlersForContainer[containerIdentifier])
-=======
-        let dao = EVCloudKitDao(containerIdentifier: containterIdentifier)
-        dao.isType = .IsPrivate
-        dao.database = dao.container.privateCloudDatabase
-        containerWrapperInstance.privateContainers[containterIdentifier] = dao
-        return dao
-    }
->>>>>>> evermeer/master
 
         return containerWrapperInstance.privateContainers[containerIdentifier]!
     }

--- a/AppMessage/AppMessage/CloudKit/EVCloudKitDataObject.swift
+++ b/AppMessage/AppMessage/CloudKit/EVCloudKitDataObject.swift
@@ -11,10 +11,25 @@ import EVReflection
 /**
 */
 public class EVCloudKitDataObject: EVObject {
+    public required init() {
+        // Initial setting required as recordID's didSet observer isn't called during initialization
+        recordIDName = recordID.recordName
+
+        super.init()
+    }
     /**
     The unique ID of the record.
     */
-    public var recordID: CKRecordID = CKRecordID(recordName: NSUUID().UUIDString)
+    public var recordID: CKRecordID = CKRecordID(recordName: NSUUID().UUIDString) {
+        didSet {
+            recordIDName = recordID.recordName
+        }
+    }
+
+    /**
+    String containing unique ID of the record for use in predicates with CloudKit subscriptions
+    */
+    public var recordIDName: String
 
     /**
     The app-defined string that identifies the type of the record.


### PR DESCRIPTION
Hi Edwin,

These changes ended up being pretty substantial. As I mentioned before, my experience with iOS/tvOS is limited, and my app, along with your project, is the first Swift coding I've done. I have no doubt that these changes could be implemented differently, and could probably be implemented in better, simpler, and/or smarter ways. I welcome your review and comments. I have already learned a lot from your project, and fully expect to learn more from us discussing these changes. I hope your schedule will allow you to do so.

Here's some notes on my thinking behind the changes:

- IMHO, adding the completion handlers while maintaining the publicDB, privateDB and ...forContainer DB constants required keeping the two fully separate. I also thought that being able to assign multiple completion handlers was a reasonable expectation. My changes support that behavior.

- I also included support for automatically calling completion handlers that are added after a constant DB entity is initialized. The new handlers are called the next time the constant entity is referenced. All assigned handlers are called again in the event of a DB reinitialization.

- A wrapper class was needed to facilitate easy removal of handlers if they were no longer needed. The wrapper class is returned as a token that the calling code is expected to keep up with, then call the wrapper's releaseToken method when the associated handler should no longer be called. I also created a manager class that I use in my app to keep up with the tokens and remove all of them when it goes out of scope. I can include that if you'd like.

- Per-user caching now uses the iCloud account's user recordId as part of the file name. This change required some semaphore usage to wait on the recordId to be retrieved the first time. Also, the local cache file name is constructed the same as before if no user recordId is returned. This may need to be changed.

- I had to change the iCloud status monitoring code from the sample code I originally provided in the feature request. I found that code was broken in varying ways depending on the OS version being used. It now uses fetchUserRecordIDWithCompletionHandler, which is also used to construct the local cache file names.

- Currently, an EVCloudKitDao DB instance has its activeUser and (new) activeUserId properties set to nil, followed by the initializeDataBase method being called, for all public and private DB instances when an iCloud status change is detected. I'm not sure if anything else needs to be reset or not (subscriptions maybe?). Please let me know or make the needed changes if other things are needed.

- EVCloudData adds a completion handler that calls disconnectAll() to each EVCloudKitDao instance that its constant entities depend on. This completion handler is given a higher priority than app-provided ones. It should always be called first, avoiding the possibility of disconnecting everything after the app-provided handlers added their needed connections.

- Being a Swift newb, I am still a little fuzzy on when closures can cause a circular reference that prevents them and their enclosing code from being released from memory. I've read about things like specifying [weak self] and [unowned self] in closures. However I'm hesitant to apply them since they can also cause premature releasing of things before everything finishes executing. I will eventually get around to using the profiler and getting a clearer understanding of when they're needed. In the meantime, discussion of this area is definitely welcomed.

- While the sample AppMessage app compiles successfully (albeit with the same warnings it exhibited prior to my changes), I didn't make any modifications to it to take advantage of my changes or to kickstart the iCloud account status monitoring. I made those changes in the tvOS app that I'm working and tested the changes from my app. We can discuss what needs to be done to integrate and reasonably exercise my changes in the sample app.

- I didn't make any documentation changes. I fully expect further changes to be needed, so I didn't see the point until everything is finalized.

- Finally, I didn't change the pod version number as I wasn't sure what you'd want it changed to with this many changes.